### PR TITLE
Fixed bug that made read only files inaccessible

### DIFF
--- a/nacl/Options.cc
+++ b/nacl/Options.cc
@@ -100,7 +100,7 @@ void CreateDirectoryOptions::Set(const pp::VarDictionary& optionsDict) {
 void OpenFileOptions::Set(const pp::VarDictionary& optionsDict) {
   TrackedOperationOptions::Set(optionsDict);
   filePath = optionsDict.Get("filePath").AsString();
-  std::string fileMode = optionsDict.Get("fileMode").AsString();
+  std::string fileMode = optionsDict.Get("mode").AsString();
   if (fileMode == "READ") {
     mode = FILE_MODE_READ;
   } else {

--- a/nacl/SambaFsp.cc
+++ b/nacl/SambaFsp.cc
@@ -413,10 +413,10 @@ void SambaFsp::openFile(const OpenFileOptions& options,
   std::string fullPath =
       getFullPathFromRelativePath(options.fileSystemId, relativePath);
 
-  // int openFileFlags = options.mode == FILE_MODE_READ ? O_RDONLY : O_WRONLY;
+  int openFileFlags = options.mode == FILE_MODE_READ ? O_RDONLY : O_RDWR;
   this->logger.Info("openFileMode: " + Util::ToString(options.mode));
   // TODO(zentaro): File modes.
-  int openFileId = smbc_open(fullPath.c_str(), O_RDWR, 0);
+  int openFileId = smbc_open(fullPath.c_str(), openFileFlags, 0);
 
   if (openFileId < 0) {
     this->LogErrorAndSetErrorResult("openFile:smbc_open", result);


### PR DESCRIPTION
Fix for #35 

`options.mode` was always FILE_MODE_WRITE, because there was a typo on when getting the `mode` from `optionsDict`

With this, it can now properly parse and pass in the correct permissions for opening the file