### PR TITLE
Using chrome local to store previous share path

### DIFF
--- a/app/local_components/display-input/display-input.html
+++ b/app/local_components/display-input/display-input.html
@@ -61,6 +61,11 @@
           var cleanedPath = mainPath.replace('\\', '/');
           this._setDisplayName(cleanedPath);
         }
+      },
+
+      setValue: function(val) {
+        this.inputField.value = val;
+        this.inputChanged();
       }
 
     });

--- a/app/local_components/domain-input/domain-input.html
+++ b/app/local_components/domain-input/domain-input.html
@@ -63,6 +63,11 @@
         } else {
           this.$.domain_label.textContent = 'Error: Invalid user name';
         }
+      },
+
+      setValue: function(val) {
+        this.inputField.value = val;
+        this.inputChanged();
       }
     });
   </script>

--- a/app/popup.js
+++ b/app/popup.js
@@ -55,8 +55,8 @@ function onMountClicked() {
   if (domain) {
     savedUser = domain + '\\' + user;
   }
-  chrome.storage.local.set({"sharePath": sharePath,
-    "shareUser": savedUser});
+  chrome.storage.local.set({"popup_share_key": sharePath,
+    "popup_user_key": savedUser});
 
   var toast = document.getElementById('errorToast');
 
@@ -189,13 +189,13 @@ function onDefaultPopupLoaded() {
   var checkBox = document.getElementById('passwordCheck');
   var credentialCollapse = document.getElementById('collapsedContent');
   var userInput = document.getElementById('user_domain_input');
-  chrome.storage.local.get(['sharePath', 'shareUser'], function(result) {
+  chrome.storage.local.get(['popup_share_key', 'popup_user_key'], function(result) {
     if (!isEmpty(result)) {
-      sharePath.setValue(result.sharePath);
-      if (result.hasOwnProperty('shareUser') && !isEmpty(result.shareUser)) {
+      sharePath.setValue(result.popup_share_key);
+      if (result.hasOwnProperty('popup_user_key') && !isEmpty(result.popup_user_key)) {
         checkBox.checked = true;
-        credentialCollapse.toggle();
-        userInput.setValue(result.shareUser);
+        credentialCollapse.show();
+        userInput.setValue(result.popup_user_key);
       }
     }
   });

--- a/app/popup.js
+++ b/app/popup.js
@@ -55,8 +55,12 @@ function onMountClicked() {
   if (domain) {
     savedUser = domain + '\\' + user;
   }
-  chrome.storage.local.set({"popup_share_key": sharePath,
-    "popup_user_key": savedUser});
+
+  var mountData = {
+    "lastSharePath" : sharePath,
+    "lastShareUser" : savedUser
+  };
+  chrome.storage.local.set({"mountData": mountData});
 
   var toast = document.getElementById('errorToast');
 
@@ -189,13 +193,15 @@ function onDefaultPopupLoaded() {
   var checkBox = document.getElementById('passwordCheck');
   var credentialCollapse = document.getElementById('collapsedContent');
   var userInput = document.getElementById('user_domain_input');
-  chrome.storage.local.get(['popup_share_key', 'popup_user_key'], function(result) {
-    if (!isEmpty(result)) {
-      sharePath.setValue(result.popup_share_key);
-      if (result.hasOwnProperty('popup_user_key') && !isEmpty(result.popup_user_key)) {
+  chrome.storage.local.get("mountData", function(result) {
+    if (!isEmpty(result) && result.hasOwnProperty('mountData')) {
+      var mountData = result.mountData;
+      sharePath.setValue(mountData.lastSharePath);
+      if (mountData.hasOwnProperty('lastShareUser') && !isEmpty(
+              mountData.lastShareUser)) {
         checkBox.checked = true;
         credentialCollapse.show();
-        userInput.setValue(result.popup_user_key);
+        userInput.setValue(mountData.lastShareUser);
       }
     }
   });

--- a/app/popup.js
+++ b/app/popup.js
@@ -51,7 +51,12 @@ function onMountClicked() {
     log.debug('domain=' + domain + ' user=' + user);
   }
   log.info("Saving current share path: " + sharePath);
-  chrome.storage.local.set({'sharePath': sharePath});
+  var savedUser = user;
+  if (domain) {
+    savedUser = domain + '\\' + user;
+  }
+  chrome.storage.local.set({"sharePath": sharePath,
+    "shareUser": savedUser});
 
   var toast = document.getElementById('errorToast');
 
@@ -181,9 +186,17 @@ function onDefaultPopupLoaded() {
   licenseLink.addEventListener('click', onLicenseLinkClicked);
 
   var sharePath = document.getElementById('sharePath');
-  chrome.storage.local.get('sharePath', function(result) {
+  var checkBox = document.getElementById('passwordCheck');
+  var credentialCollapse = document.getElementById('collapsedContent');
+  var userInput = document.getElementById('user_domain_input');
+  chrome.storage.local.get(['sharePath', 'shareUser'], function(result) {
     if (!isEmpty(result)) {
       sharePath.setValue(result.sharePath);
+      if (result.hasOwnProperty('shareUser') && !isEmpty(result.shareUser)) {
+        checkBox.checked = true;
+        credentialCollapse.toggle();
+        userInput.setValue(result.shareUser);
+      }
     }
   });
 

--- a/app/popup.js
+++ b/app/popup.js
@@ -50,6 +50,8 @@ function onMountClicked() {
     saveCredentials = savePasswordCheckbox.checked;
     log.debug('domain=' + domain + ' user=' + user);
   }
+  log.info("Saving current share path: " + sharePath);
+  chrome.storage.local.set({'sharePath': sharePath});
 
   var toast = document.getElementById('errorToast');
 
@@ -177,6 +179,13 @@ function onDefaultPopupLoaded() {
   cancelButton.addEventListener('click', onCancel);
   passwordCheck.addEventListener('change', onPasswordChecked);
   licenseLink.addEventListener('click', onLicenseLinkClicked);
+
+  var sharePath = document.getElementById('sharePath');
+  chrome.storage.local.get('sharePath', function(result) {
+    if (!isEmpty(result)) {
+      sharePath.setValue(result.sharePath);
+    }
+  });
 
   enumerateFileShares();
   log.debug('Loading lmHosts');

--- a/app/utils.js
+++ b/app/utils.js
@@ -258,3 +258,11 @@ function sliceArray(arr, begin, length) {
 function clamp(value, min, max) {
   return Math.max(min, Math.min(value, max));
 }
+
+function isEmpty(obj) {
+  for(var key in obj) {
+    if(obj.hasOwnProperty(key))
+      return false;
+  }
+  return true;
+}


### PR DESCRIPTION
Resolves #43 

Assumptions:

1. I am storing only the share path, and not the username
2. I am using `storage.local` to store share path here
3. I am storing the share path even if the mount is unsuccessful 
4. I am not including a check box or anything to make it optional to store the previous share paths

Let me know what you think of this, I am very open to changing any aspect of my implementation